### PR TITLE
Implement core features of ResultFragment

### DIFF
--- a/app/src/main/java/com/github/bnguyen527/snaptuney/ConfigurationsFragment.kt
+++ b/app/src/main/java/com/github/bnguyen527/snaptuney/ConfigurationsFragment.kt
@@ -83,7 +83,7 @@ class ConfigurationsFragment : Fragment() {
                 val secondSource = secondSourceSpinner.selectedItem as PlaylistSimple
                 findNavController().navigate(
                     ConfigurationsFragmentDirections.actionCreatePlaylist(
-                        durationEditText.text.toString().toInt(),
+                        durationEditText.text.toString().toLong(),
                         firstSource.id,
                         firstSource.owner.id,
                         secondSource.id,

--- a/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
+++ b/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
@@ -108,26 +108,34 @@ private class Tracklist(
 private class PlaylistTrackAdapter(private val tracklist: List<PlaylistTrack>) :
     RecyclerView.Adapter<PlaylistTrackAdapter.PlaylistTrackViewHolder>() {
 
-    class PlaylistTrackViewHolder(val binding: ListItemPlaylistTrackBinding) :
-        RecyclerView.ViewHolder(binding.root)
+    class PlaylistTrackViewHolder private constructor(private val binding: ListItemPlaylistTrackBinding) :
+        RecyclerView.ViewHolder(binding.root) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = PlaylistTrackViewHolder(
-        ListItemPlaylistTrackBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
-        )
-    )
-
-    override fun onBindViewHolder(holder: PlaylistTrackViewHolder, position: Int) {
-        tracklist[position].track.also { track ->
-            holder.binding.apply {
-                playlistTrackTitleTextView.text = track.name
-                playlistTrackArtistsTextView.text = track.artists.joinToString { it.name }
-                playlistTrackDurationTextView.text =
-                    DateUtils.formatElapsedTime(convertMilliToSeconds(track.duration_ms))
+        fun bind(playlistTrack: PlaylistTrack) {
+            playlistTrack.track.let { track ->
+                binding.apply {
+                    playlistTrackTitleTextView.text = track.name
+                    playlistTrackArtistsTextView.text = track.artists.joinToString { it.name }
+                    playlistTrackDurationTextView.text =
+                        DateUtils.formatElapsedTime(convertMilliToSeconds(track.duration_ms))
+                }
             }
         }
+
+        companion object {
+            fun from(parent: ViewGroup) = PlaylistTrackViewHolder(
+                ListItemPlaylistTrackBinding.inflate(
+                    LayoutInflater.from(parent.context), parent, false
+                )
+            )
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+        PlaylistTrackViewHolder.from(parent)
+
+    override fun onBindViewHolder(holder: PlaylistTrackViewHolder, position: Int) {
+        holder.bind(tracklist[position])
     }
 
     override fun getItemCount() = tracklist.size

--- a/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
+++ b/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
@@ -19,16 +19,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import retrofit.RetrofitError
-import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 
-private typealias PlaylistTrackWithDurationSeconds = Pair<PlaylistTrack, Int>
+private typealias PlaylistTrackWithDurationSeconds = Pair<PlaylistTrack, Long>
 
 /**
  * Represents a tracklist to be created object with input sources [firstSource] and [secondSource]
  * and a target duration of [targetDuration] minutes.
  */
 private class Tracklist(
-    val targetDuration: Int,
+    val targetDuration: Long,
     val firstSource: List<PlaylistTrack>,
     val secondSource: List<PlaylistTrack>
 ) {
@@ -74,9 +74,7 @@ private class Tracklist(
         Log.d(
             TAG,
             "Tracklist of ${tracklist.size} track(s) and of length ${
-                DateUtils.formatElapsedTime(
-                    targetDuration.times(60).minus(secondsToTarget).toLong()
-                )
+                DateUtils.formatElapsedTime(targetDuration.times(60).minus(secondsToTarget))
             }"
         )
         Log.i(TAG, "Tracklist initialized")
@@ -85,7 +83,7 @@ private class Tracklist(
 
     /** Returns a Pair of the next track coupled with its duration in seconds. */
     private fun Iterator<PlaylistTrack>.nextWithDurationSeconds() =
-        with(next()) { Pair(this, track.duration_ms.div(1000.0).roundToInt()) }
+        with(next()) { Pair(this, track.duration_ms.div(1000.0).roundToLong()) }
 
     /** Returns true if the track is addable. */
     private fun PlaylistTrackWithDurationSeconds.shouldAdd() =

--- a/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
+++ b/app/src/main/java/com/github/bnguyen527/snaptuney/ResultFragment.kt
@@ -7,10 +7,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.github.bnguyen527.snaptuney.databinding.FragmentResultBinding
+import kaaes.spotify.webapi.android.SpotifyError
 import kaaes.spotify.webapi.android.SpotifyService
+import kaaes.spotify.webapi.android.models.PlaylistTrack
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import retrofit.RetrofitError
 
 class ResultFragment : Fragment() {
     private var _binding: FragmentResultBinding? = null
@@ -47,7 +54,31 @@ class ResultFragment : Fragment() {
         val configurations by navArgs<ResultFragmentArgs>()
         Log.d(TAG, configurations.toString())
         Log.i(TAG, "Received input configurations")
+        lifecycleScope.launch {
+            with(configurations) {
+                fetchPlaylistTracks(firstSourceOwnerId, firstSourceId)
+                fetchPlaylistTracks(secondSourceOwnerId, secondSourceId)
+            }
+        }
     }
+
+    /**
+     * Returns fetched playlist tracks of playlist [playlistId] owned by user [ownerId] and empty
+     * list when API request response is an error.
+     */
+    private suspend fun fetchPlaylistTracks(ownerId: String, playlistId: String) =
+        withContext(Dispatchers.IO) {
+            try {
+                val playlistTracksPager =
+                    spotify.getPlaylistTracks(ownerId, playlistId, PLAYLIST_TRACKS_QUERY_OPTIONS)
+                Log.d(TAG, "Fetched ${playlistTracksPager.items.size} tracks")
+                Log.i(TAG, "Fetched tracks from $playlistId")
+                playlistTracksPager.items
+            } catch (error: RetrofitError) {
+                Log.e(TAG, SpotifyError.fromRetrofitError(error).toString())
+                emptyList<PlaylistTrack>()
+            }
+        }
 
     override fun onDestroyView() {
         super.onDestroyView()
@@ -61,5 +92,9 @@ class ResultFragment : Fragment() {
 
     companion object {
         private val TAG = ResultFragment::class.java.simpleName
+        private val PLAYLIST_TRACKS_QUERY_OPTIONS = mapOf(
+            "fields" to "items.track(artists.name,duration_ms,id,name,uri)",
+            "market" to "from_token"
+        )
     }
 }

--- a/app/src/main/java/com/github/bnguyen527/snaptuney/WelcomeActivity.kt
+++ b/app/src/main/java/com/github/bnguyen527/snaptuney/WelcomeActivity.kt
@@ -76,7 +76,11 @@ class WelcomeActivity : AppCompatActivity() {
         const val EXTRA_ACCESS_TOKEN = "com.github.bnguyen527.snaptuney.EXTRA_ACCESS_TOKEN"
         private const val CLIENT_ID = "cceb1c861c3a4cbfb6de3c67dfc32179"
         private const val REDIRECT_URI = "com.github.bnguyen527.snaptuney://callback"
-        private val AUTH_SCOPES = listOf("playlist-read-private", "playlist-read-collaborative")
+        private val AUTH_SCOPES = listOf(
+            "playlist-read-private",
+            "playlist-read-collaborative",
+            "playlist-modify-private"
+        )
         private const val REQUEST_CODE = 1337
     }
 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -24,7 +24,7 @@
             app:destination="@id/configurationsFragment" />
         <argument
             android:name="targetDuration"
-            app:argType="integer" />
+            app:argType="long" />
         <argument
             android:name="firstSourceId"
             app:argType="string" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,9 @@
     <string name="login_failed_toast_text">Login failed!</string>
     <string name="login_canceled_toast_text">Login canceled</string>
     <string name="login_success_toast_text">Logged in successfully!</string>
+    <string name="playlist_description">Created by SnapTuney.</string>
+    <string name="save_playlist_success_toast_text">Saved playlist successfully!</string>
+    <string name="save_playlist_failed_toast_text">Saving playlist failed!</string>
     <plurals name="playlist_dropdown_track_total_text_view_text">
         <item quantity="one">%d track</item>
         <item quantity="other">%d tracks</item>


### PR DESCRIPTION
Able to compute new tracklist from input configurations, display it in the RecyclerView and save playlist to Spotify on Save button tap. New Configurations button's behavior remains unchanged.

No interactive features (e.g. add, remove tracks by interacting with the RecyclerView) is implemented yet.

Data and cache persisting is also not implemented yet, so orientation changes, killing and reopening app, or navigating back after New Configurations button tap will potentially lead to duplicated created playlists in Spotify or new tracklist generated (instead of the previous created tracklist, which is what user expects) (because Navigation component replaces, not hides, old fragments, so they are recreated when user navigates back, thus leading to all the initializations, including tracklist generation, are executed again).

Nevertheless, app core functionalities are complete at this point.